### PR TITLE
feat(DIGITAL-3023): prevent default on searchinput for Enter key

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,13 @@ function App() {
   const setSearchControl = () => {
     if (Config.Map.EnableAddressSearch) {
       mapRef.current.addControl(SearchControlOverlay())
-      document.querySelector('.search-button').click()
+      document.querySelector('#searchtext18').addEventListener('keypress', searchInputHandler)
+    }
+  }
+
+  const searchInputHandler = (event) => {
+    if(event.key === 'Enter'){
+      event.preventDefault()
     }
   }
 


### PR DESCRIPTION
### Description
Preventdefault when 'Enter' key is pressed. This does not trigger the search as the search is triggered on debounce of user typing, so the event is swallowed.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary